### PR TITLE
Use stdout option for encryption output

### DIFF
--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -15,7 +15,7 @@ const delay = (ms) => {
 
 function App() {
   const { dispatch } = useStore();
-  const [output, setOutput] = useState({ stdout: '', stderr: '', text: '', file: null });
+  const [output, setOutput] = useState({ stdout: '', stderr: '', file: null });
   const [inputFiles, setInputFiles] = useState([]);
 
   const runCommand = async (args, commandType = '', files = [], text = '') => {
@@ -78,7 +78,7 @@ function App() {
       <label className="mt-3">Output</label>
       <CommandLine
         runCommand={runCommand}
-        result={{ stdout: output.stdout, stderr: output.stderr, text: output.text }}
+        result={{ stdout: output.stdout, stderr: output.stderr }}
       ></CommandLine>
     </div>
   );

--- a/src/components/card-control/components/tab-encryption/TabEncryption.js
+++ b/src/components/card-control/components/tab-encryption/TabEncryption.js
@@ -270,6 +270,7 @@ function TabEncryption({ runCommand }) {
                     value="1"
                     checked={enc.a}
                     onChange={set('a')}
+                    disabled={enc.text}
                   >
                     Base64
                   </ToggleButton>

--- a/src/components/command-line/CommandLine.js
+++ b/src/components/command-line/CommandLine.js
@@ -7,16 +7,6 @@ function CommandLine({ runCommand, result }) {
   const { state, dispatch } = useStore();
   const input = useRef();
 
-  const diplayResult = (result) => {
-    if (result.text) {
-      return `${result.stderr}\n\n${result.text}`;
-    }
-    if (result.stdout) {
-      return result.stdout;
-    }
-    return result.stderr;
-  };
-
   const handleSubmit = (event) => {
     event.preventDefault();
     dispatch({ type: 'SET_COMMAND', command: input.current.value });
@@ -27,13 +17,16 @@ function CommandLine({ runCommand, result }) {
   return (
     <div className="CommandLine">
       <div className="CommandLine-output">
-        <p className="CommandLine-command">{state.command ? `OpenSSL> ${state.command}` : ''}</p>
+        {state.command && <p className="CommandLine-command">{`OpenSSL> ${state.command}`}</p>}
         {state.isLoading ? (
           <div className="CommandLine-loader">
             <div className="spinner-border text-light" role="status"></div>
           </div>
         ) : (
-          <p>{diplayResult(result)}</p>
+          <>
+            {result.stderr && <p>{`${result.stderr}\n`}</p>}
+            {result.stdout && <p>{result.stdout}</p>}
+          </>
         )}
       </div>
       <form onSubmit={handleSubmit}>

--- a/src/core/command.js
+++ b/src/core/command.js
@@ -61,7 +61,6 @@ class Command {
     let output = {
       stdout: '',
       stderr: '',
-      text: '',
       file: null,
     };
 
@@ -95,11 +94,7 @@ class Command {
 
         instance.callMain(argsArray);
 
-        if (inputText) {
-          output.text = instance['FS'].readFile(this.getFileOutParameter(argsArray), {
-            encoding: 'utf8',
-          });
-        } else if (this.getFileOutParameter(argsArray)) {
+        if (this.getFileOutParameter(argsArray)) {
           const readFileBuffer = instance['FS'].readFile(this.getFileOutParameter(argsArray), {
             encoding: 'binary',
           });

--- a/src/core/command.test.js
+++ b/src/core/command.test.js
@@ -6,7 +6,7 @@ let inputText;
 
 beforeAll(() => {
   inputFile = new File(['This is a test'], 'testFile');
-  inputText = 'This is a text';
+  inputText = 'This is a text\n';
 });
 
 describe('test if result observable emits values', () => {
@@ -30,9 +30,9 @@ describe('test if result observable emits values', () => {
 
   test('result has a text', (done) => {
     const command = new Command();
-    command.run('enc -base64 -in file -out output', null, inputText);
+    command.run('enc -base64 -in file', null, inputText);
     command.resultAsObservable.pipe(take(1)).subscribe((value) => {
-      expect(value.text).toBeTruthy();
+      expect(value.stdout).toBeTruthy();
       done();
     });
   });
@@ -144,13 +144,14 @@ describe('symmetric encryption methods with an input file', () => {
 describe('symmetric encryption methods with an input text in a base64 format', () => {
   test('aes-256-cbc encryption and decryption', (done) => {
     const command = new Command();
-    command.run(`enc -e -a -aes-256-cbc -k 1234 -in file -out output`, null, inputText);
+    command.run(`enc -e -a -aes-256-cbc -k 1234 -in file`, null, inputText);
     command.resultAsObservable.pipe(take(2)).subscribe((value) => {
-      if (value.text !== inputText) {
-        command.run(`enc -d -a -aes-256-cbc -k 1234 -in file -out output`, null, value.text);
+      console.log(value);
+      if (value.stdout !== inputText) {
+        command.run(`enc -d -a -aes-256-cbc -k 1234 -in file`, null, value.stdout);
       }
-      if (value.text === inputText) {
-        expect(value.text).toEqual(inputText);
+      if (value.stdout === inputText) {
+        expect(value.stdout).toEqual(inputText);
         done();
       }
     });
@@ -158,13 +159,13 @@ describe('symmetric encryption methods with an input text in a base64 format', (
 
   test('camellia-256-cbc encryption and decryption', (done) => {
     const command = new Command();
-    command.run(`enc -e -a -camellia-256-cbc -k 1234 -in file -out output`, null, inputText);
+    command.run(`enc -e -a -camellia-256-cbc -k 1234 -in file`, null, inputText);
     command.resultAsObservable.pipe(take(2)).subscribe((value) => {
-      if (value.text !== inputText) {
-        command.run(`enc -d -a -camellia-256-cbc -k 1234 -in file -out output`, null, value.text);
+      if (value.stdout !== inputText) {
+        command.run(`enc -d -a -camellia-256-cbc -k 1234 -in file`, null, value.stdout);
       }
-      if (value.text === inputText) {
-        expect(value.text).toEqual(inputText);
+      if (value.stdout === inputText) {
+        expect(value.stdout).toEqual(inputText);
         done();
       }
     });
@@ -172,13 +173,13 @@ describe('symmetric encryption methods with an input text in a base64 format', (
 
   test('des3 encryption and decryption', (done) => {
     const command = new Command();
-    command.run(`enc -e -a -des3 -k 1234 -in file -out output`, null, inputText);
+    command.run(`enc -e -a -des3 -k 1234 -in file`, null, inputText);
     command.resultAsObservable.pipe(take(2)).subscribe((value) => {
-      if (value.text !== inputText) {
-        command.run(`enc -d -a -des3 -k 1234 -in file -out output`, null, value.text);
+      if (value.stdout !== inputText) {
+        command.run(`enc -d -a -des3 -k 1234 -in file`, null, value.stdout);
       }
-      if (value.text === inputText) {
-        expect(value.text).toEqual(inputText);
+      if (value.stdout === inputText) {
+        expect(value.stdout).toEqual(inputText);
         done();
       }
     });
@@ -186,13 +187,13 @@ describe('symmetric encryption methods with an input text in a base64 format', (
 
   test('des-ede3-cbc encryption and decryption', (done) => {
     const command = new Command();
-    command.run(`enc -e -a -des-ede3-cbc -k 1234 -in file -out output`, null, inputText);
+    command.run(`enc -e -a -des-ede3-cbc -k 1234 -in file`, null, inputText);
     command.resultAsObservable.pipe(take(2)).subscribe((value) => {
-      if (value.text !== inputText) {
-        command.run(`enc -d -a -des-ede3-cbc -k 1234 -in file -out output`, null, value.text);
+      if (value.stdout !== inputText) {
+        command.run(`enc -d -a -des-ede3-cbc -k 1234 -in file`, null, value.stdout);
       }
-      if (value.text === inputText) {
-        expect(value.text).toEqual(inputText);
+      if (value.stdout === inputText) {
+        expect(value.stdout).toEqual(inputText);
         done();
       }
     });

--- a/src/core/commandBuilder.js
+++ b/src/core/commandBuilder.js
@@ -17,7 +17,6 @@ const buildEnc = (enc) => {
         break;
       case 'outFile':
         if (!enc.text) command.push(`-out ${enc.outFile}`);
-        else command.push('-out output');
         break;
       case 'k':
         if (enc.k) command.push('-k');
@@ -41,7 +40,7 @@ const buildEnc = (enc) => {
         if (enc.iv) command.push(enc.ivVal);
         break;
       case 'a':
-        if (enc.a) command.push('-a');
+        if (enc.a || enc.text) command.push('-a');
         break;
       default:
         break;


### PR DESCRIPTION
## Description
This PR removes the text property from the the output object of an executed command. Changed regarding command which now writes its output to stdout.

## Checklist
- [x] Remove temporary file creation for output text
- [x] Remove text property from output object
- [x] Adapt tests